### PR TITLE
general: make CONFIG_NVMEVIRT_SSD to be default

### DIFF
--- a/Kbuild
+++ b/Kbuild
@@ -1,6 +1,6 @@
 # Select one of the targets to build
-CONFIG_NVMEVIRT_NVM := y
-#CONFIG_NVMEVIRT_SSD := y
+#CONFIG_NVMEVIRT_NVM := y
+CONFIG_NVMEVIRT_SSD := y
 #CONFIG_NVMEVIRT_ZNS := y
 #CONFIG_NVMEVIRT_KV := y
 


### PR DESCRIPTION
Currently `CONFIG_NVMEVIRT_NVM` is the default on Kbuild.  Since team EatingMuch is likely to be working with SSD rather than NVM, it is helpful to change the setting of Kbuild.