### PR TITLE
Hyeongtak/multi stream draft

### DIFF
--- a/conv_ftl.c
+++ b/conv_ftl.c
@@ -33,17 +33,10 @@ static bool should_gc(struct conv_ftl *conv_ftl)
 	return (total_free_line_cnt <= conv_ftl->cp.gc_thres_lines);
 }
 
-static inline bool should_gc_high(struct conv_ftl *conv_ftl)
+static inline bool should_gc_high(struct conv_ftl *conv_ftl, uint32_t stream_id)
 {
-	int i;
-
-	for (i = 0; i < get_nr_streams(conv_ftl); i++) {
-		if (conv_ftl->lm[i].free_line_cnt <=
-		    conv_ftl->cp.gc_thres_lines_high)
-			return true;
-	}
-
-	return false;
+	return (conv_ftl->lm[stream_id].free_line_cnt <=
+		conv_ftl->cp.gc_thres_lines_high);
 }
 
 static inline struct ppa get_maptbl_ent(struct conv_ftl *conv_ftl, uint64_t lpn)
@@ -113,18 +106,20 @@ static inline void victim_line_set_pos(void *a, size_t pos)
 	((struct line *)a)->pos = pos;
 }
 
-static inline void consume_write_credit(struct conv_ftl *conv_ftl)
+static inline void consume_write_credit(struct conv_ftl *conv_ftl,
+					uint32_t stream_id)
 {
-	conv_ftl->wfc.write_credits--;
+	conv_ftl->wfc[stream_id].write_credits--;
 }
 
-static void foreground_gc(struct conv_ftl *conv_ftl);
+static void foreground_gc(struct conv_ftl *conv_ftl, uint32_t stream_id);
 
-static inline void check_and_refill_write_credit(struct conv_ftl *conv_ftl)
+static inline void check_and_refill_write_credit(struct conv_ftl *conv_ftl,
+						 uint32_t stream_id)
 {
-	struct write_flow_control *wfc = &(conv_ftl->wfc);
+	struct write_flow_control *wfc = &(conv_ftl->wfc[stream_id]);
 	if (wfc->write_credits <= 0) {
-		foreground_gc(conv_ftl);
+		foreground_gc(conv_ftl, stream_id);
 
 		wfc->write_credits += wfc->credits_to_refill;
 	}
@@ -141,11 +136,20 @@ static void init_write_pointers(struct conv_ftl *conv_ftl)
 			    __func__);
 		return;
 	}
+
+	conv_ftl->gc_wp = kmalloc(sizeof(struct write_pointer) * nr_streams,
+			       GFP_KERNEL);
+	if (!conv_ftl->gc_wp) {
+		NVMEV_ERROR("%s: Failed to allocate memory for gc write_pointer\n",
+			    __func__);
+		return;
+	}
 }
 
 static void remove_write_pointers(struct conv_ftl *conv_ftl)
 {
 	kfree(conv_ftl->wp);
+	kfree(conv_ftl->gc_wp);
 }
 
 static void init_lines(struct conv_ftl *conv_ftl)
@@ -210,11 +214,29 @@ static void remove_lines(struct conv_ftl *conv_ftl)
 
 static void init_write_flow_control(struct conv_ftl *conv_ftl)
 {
-	struct write_flow_control *wfc = &(conv_ftl->wfc);
+	uint32_t nr_streams = get_nr_streams(conv_ftl);
+	struct write_flow_control *wfc;
 	struct ssdparams *spp = &conv_ftl->ssd->sp;
+	int i;
 
-	wfc->write_credits = spp->pgs_per_line;
-	wfc->credits_to_refill = spp->pgs_per_line;
+	conv_ftl->wfc = kmalloc(sizeof(struct write_flow_control) * nr_streams, GFP_KERNEL);
+
+	for (i = 0; i < nr_streams; i++) {
+		if (!conv_ftl->wfc) {
+			NVMEV_ERROR("%s: Failed to allocate memory for write_flow_control\n", __func__);
+			return;
+		}
+		wfc = &(conv_ftl->wfc[i]);
+		wfc->write_credits = spp->pgs_per_line;
+		wfc->credits_to_refill = spp->pgs_per_line;
+	}
+}
+
+static void remove_write_flow_controls(struct conv_ftl *conv_ftl)
+{
+	uint32_t nr_streams = get_nr_streams(conv_ftl);
+
+	kfree(conv_ftl->wfc);
 }
 
 static inline void check_addr(int a, int max)
@@ -245,8 +267,7 @@ static struct write_pointer *__get_wp(struct conv_ftl *ftl, uint32_t io_type,
 	if (io_type == USER_IO) {
 		return &ftl->wp[stream_id];
 	} else if (io_type == GC_IO) {
-		/* TODO: gc may need to be stream-aware */
-		return &ftl->gc_wp;
+		return &ftl->gc_wp[stream_id];
 	}
 
 	NVMEV_ASSERT(0);
@@ -422,7 +443,6 @@ static void conv_init_ftl(struct conv_ftl *conv_ftl, struct convparams *cpp, str
 
 	/*
 	 * initialize write pointers
-	 * TODO: gc_wp needs initialization for adopting multi-stream
 	 */
 	init_write_pointers(conv_ftl);
 
@@ -440,6 +460,7 @@ static void conv_init_ftl(struct conv_ftl *conv_ftl, struct convparams *cpp, str
 
 static void conv_remove_ftl(struct conv_ftl *conv_ftl)
 {
+	remove_write_flow_controls(conv_ftl);
 	remove_lines(conv_ftl);
 	remove_rmap(conv_ftl);
 	remove_maptbl(conv_ftl);
@@ -687,7 +708,7 @@ static uint64_t gc_write_page(struct conv_ftl *conv_ftl, struct ppa *old_ppa)
 	uint64_t lpn = get_rmap_ent(conv_ftl, old_ppa);
 
 	NVMEV_ASSERT(valid_lpn(conv_ftl, lpn));
-	new_ppa = get_new_page(conv_ftl, GC_IO, 0);
+	new_ppa = get_new_page(conv_ftl, GC_IO, get_stream_id(old_ppa));
 	/* update maptbl */
 	set_maptbl_ent(conv_ftl, lpn, &new_ppa);
 	/* update rmap */
@@ -696,7 +717,7 @@ static uint64_t gc_write_page(struct conv_ftl *conv_ftl, struct ppa *old_ppa)
 	mark_page_valid(conv_ftl, &new_ppa);
 
 	/* need to advance the write pointer here */
-	advance_write_pointer(conv_ftl, GC_IO, 0);
+	advance_write_pointer(conv_ftl, GC_IO, get_stream_id(old_ppa));
 
 	if (cpp->enable_gc_delay) {
 		struct nand_cmd gcw = {
@@ -726,26 +747,8 @@ static uint64_t gc_write_page(struct conv_ftl *conv_ftl, struct ppa *old_ppa)
 	return 0;
 }
 
-/* return lm with most number of free lines */
-static uint32_t find_lm(struct conv_ftl *conv_ftl)
+static struct line *select_victim_line(struct conv_ftl *conv_ftl, bool force, uint32_t stream_id)
 {
-	int max_index = 0;
-	int max_free_lines = conv_ftl->lm[0].free_line_cnt;
-	uint32_t nr_streams = get_nr_streams(conv_ftl);
-
-	for (int i = 1; i < nr_streams; i++) {
-		if (conv_ftl->lm[i].free_line_cnt > max_free_lines) {
-			max_free_lines = conv_ftl->lm[i].free_line_cnt;
-			max_index = i;
-		}
-	}
-
-	return max_index;
-}
-
-static struct line *select_victim_line(struct conv_ftl *conv_ftl, bool force)
-{
-	uint32_t stream_id = find_lm(conv_ftl);
 	struct ssdparams *spp = &conv_ftl->ssd->sp;
 	struct line_mgmt *lm = &conv_ftl->lm[stream_id];
 	struct line *victim_line = NULL;
@@ -853,58 +856,56 @@ static void mark_line_free(struct conv_ftl *conv_ftl, struct ppa *ppa)
 	lm->free_line_cnt++;
 }
 
-static int do_gc(struct conv_ftl *conv_ftl, bool force)
+static int do_gc(struct conv_ftl *conv_ftl, bool force, uint32_t stream_id)
 {
 	struct line *victim_line = NULL;
 	struct ssdparams *spp = &conv_ftl->ssd->sp;
 	struct ppa ppa;
 	int flashpg;
 
-	victim_line = select_victim_line(conv_ftl, force);
+	victim_line = select_victim_line(conv_ftl, force, stream_id);
 	if (!victim_line) {
 		return -1;
 	}
 
 	ppa.g.blk = victim_line->id;
 	NVMEV_DEBUG_VERBOSE("GC-ing line:%d,ipc=%d(%d),victim=%d,full=%d,free=%d\n", ppa.g.blk,
-		    victim_line->ipc, victim_line->vpc, conv_ftl->lm[0].victim_line_cnt,
-		    conv_ftl->lm[0].full_line_cnt, conv_ftl->lm[0].free_line_cnt);
+		    victim_line->ipc, victim_line->vpc, conv_ftl->lm[stream_id].victim_line_cnt,
+		    conv_ftl->lm[stream_id].full_line_cnt, conv_ftl->lm[stream_id].free_line_cnt);
 
-	conv_ftl->wfc.credits_to_refill = victim_line->ipc;
+	conv_ftl->wfc[stream_id].credits_to_refill = victim_line->ipc;
 
 	/* copy back valid data */
 	for (flashpg = 0; flashpg < spp->flashpgs_per_blk; flashpg++) {
-		int ch, lun;
+		int ch, lun = stream_id;
 
 		ppa.g.pg = flashpg * spp->pgs_per_flashpg;
 		for (ch = 0; ch < spp->nchs; ch++) {
-			for (lun = 0; lun < spp->luns_per_ch; lun++) {
-				struct nand_lun *lunp;
+			struct nand_lun *lunp;
 
-				ppa.g.ch = ch;
-				ppa.g.lun = lun;
-				ppa.g.pl = 0;
-				lunp = get_lun(conv_ftl->ssd, &ppa);
-				clean_one_flashpg(conv_ftl, &ppa);
+			ppa.g.ch = ch;
+			ppa.g.lun = lun;
+			ppa.g.pl = 0;
+			lunp = get_lun(conv_ftl->ssd, &ppa);
+			clean_one_flashpg(conv_ftl, &ppa);
 
-				if (flashpg == (spp->flashpgs_per_blk - 1)) {
-					struct convparams *cpp = &conv_ftl->cp;
+			if (flashpg == (spp->flashpgs_per_blk - 1)) {
+				struct convparams *cpp = &conv_ftl->cp;
 
-					mark_block_free(conv_ftl, &ppa);
+				mark_block_free(conv_ftl, &ppa);
 
-					if (cpp->enable_gc_delay) {
-						struct nand_cmd gce = {
-							.type = GC_IO,
-							.cmd = NAND_ERASE,
-							.stime = 0,
-							.interleave_pci_dma = false,
-							.ppa = &ppa,
-						};
-						ssd_advance_nand(conv_ftl->ssd, &gce);
-					}
-
-					lunp->gc_endtime = lunp->next_lun_avail_time;
+				if (cpp->enable_gc_delay) {
+					struct nand_cmd gce = {
+						.type = GC_IO,
+						.cmd = NAND_ERASE,
+						.stime = 0,
+						.interleave_pci_dma = false,
+						.ppa = &ppa,
+					};
+					ssd_advance_nand(conv_ftl->ssd, &gce);
 				}
+
+				lunp->gc_endtime = lunp->next_lun_avail_time;
 			}
 		}
 	}
@@ -915,12 +916,12 @@ static int do_gc(struct conv_ftl *conv_ftl, bool force)
 	return 0;
 }
 
-static void foreground_gc(struct conv_ftl *conv_ftl)
+static void foreground_gc(struct conv_ftl *conv_ftl, uint32_t stream_id)
 {
-	if (should_gc_high(conv_ftl)) {
+	if (should_gc_high(conv_ftl, stream_id)) {
 		NVMEV_DEBUG_VERBOSE("should_gc_high passed");
 		/* perform GC here until !should_gc(conv_ftl) */
-		do_gc(conv_ftl, true);
+		do_gc(conv_ftl, true, stream_id);
 	}
 }
 
@@ -1078,6 +1079,8 @@ static bool conv_write(struct nvmev_ns *ns, struct nvmev_request *req, struct nv
 		uint64_t nsecs_completed = 0;
 		struct ppa ppa;
 
+		NVMEV_DEBUG("%s: lpn: %lld", __func__, lpn);
+
 		conv_ftl = &conv_ftls[lpn % nr_parts];
 		local_lpn = lpn / nr_parts;
 		ppa = get_maptbl_ent(
@@ -1113,8 +1116,8 @@ static bool conv_write(struct nvmev_ns *ns, struct nvmev_request *req, struct nv
 						    spp->pgs_per_oneshotpg * spp->pgsz);
 		}
 
-		consume_write_credit(conv_ftl);
-		check_and_refill_write_credit(conv_ftl);
+		consume_write_credit(conv_ftl, stream_id);
+		check_and_refill_write_credit(conv_ftl, stream_id);
 	}
 
 	if ((cmd->rw.control & NVME_RW_FUA) || (spp->write_early_completion == 0)) {

--- a/conv_ftl.h
+++ b/conv_ftl.h
@@ -62,9 +62,9 @@ struct conv_ftl {
 	struct ppa *maptbl; /* page level mapping table */
 	uint64_t *rmap; /* reverse mapptbl, assume it's stored in OOB */
 	struct write_pointer *wp;
-	struct write_pointer gc_wp;
+	struct write_pointer *gc_wp;
 	struct line_mgmt *lm;
-	struct write_flow_control wfc;	/* TODO: consider stream */
+	struct write_flow_control *wfc;
 };
 
 void conv_init_namespace(struct nvmev_ns *ns, uint32_t id, uint64_t size, void *mapped_addr,

--- a/conv_ftl.h
+++ b/conv_ftl.h
@@ -61,10 +61,10 @@ struct conv_ftl {
 	struct convparams cp;
 	struct ppa *maptbl; /* page level mapping table */
 	uint64_t *rmap; /* reverse mapptbl, assume it's stored in OOB */
-	struct write_pointer wp;
+	struct write_pointer *wp;
 	struct write_pointer gc_wp;
-	struct line_mgmt lm;
-	struct write_flow_control wfc;
+	struct line_mgmt *lm;
+	struct write_flow_control wfc;	/* TODO: consider stream */
 };
 
 void conv_init_namespace(struct nvmev_ns *ns, uint32_t id, uint64_t size, void *mapped_addr,

--- a/nvme.h
+++ b/nvme.h
@@ -367,7 +367,8 @@ struct nvme_rw_command {
 	__le64 slba;
 	__le16 length;
 	__le16 control;
-	__le32 dsmgmt;
+	__le16 dsmgmt;
+	__le16 dspec;
 	__le32 reftag;
 	__le16 apptag;
 	__le16 appmask;

--- a/ssd.c
+++ b/ssd.c
@@ -150,7 +150,7 @@ void ssd_init_params(struct ssdparams *spp, uint64_t capacity, uint32_t nparts)
 	spp->tt_luns = spp->luns_per_ch * spp->nchs;
 
 	/* line is special, put it at the end */
-	spp->blks_per_line = spp->tt_luns; /* TODO: to fix under multiplanes */
+	spp->blks_per_line = spp->nchs; /* TODO: to fix under multiplanes */
 	spp->pgs_per_line = spp->blks_per_line * spp->pgs_per_blk;
 	spp->secs_per_line = spp->pgs_per_line * spp->secs_per_pg;
 	spp->tt_lines = spp->blks_per_lun;


### PR DESCRIPTION
This patch series is the draft version of multi-stream SSD in NVMeVirt.
 - enable nvme command (write command) to get dspec value
 - adopt stream on conventional SSD by making each LUN a stream

A simple test command is as follows:

```
$ printf "hello world" | dd bs=1 count=11 conv=notrunc of=data.bin
$ dd if=/dev/zero bs=1 count=131072 conv=notrunc of=data.bin oflag=append
$ nvme io-passthru /dev/nvme0n1 --opcode=0x01 --namespace-id=1 --data-len=16384 --cdw10=0 --cdw11=0 --cdw12=0x1f --cdw13=0 --write --raw-binary < data.bin
```

Below is the test result using fio [1]

```
$ sudo fio ./multistream_fio.conf
  job0: (g=0): rw=randwrite, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=spdk, iodepth=1
  ...
  job1: (g=0): rw=randwrite, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=spdk, iodepth=1
  ...
  fio-3.37-28-g3ed8e
  Starting 8 threads
  Jobs: 6 (f=6): [E(1),f(2),w(1),f(2),E(1),w(1)][100.0%][w=98.1MiB/s][w=25.1k IOPS][eta 00m:00s]
  job0: (groupid=0, jobs=8): err= 0: pid=1244: Mon May 20 07:54:31 2024
    write: IOPS=39.7k, BW=155MiB/s (162MB/s)(9300MiB/60012msec); 0 zone resets
      slat (nsec): min=99, max=21005k, avg=328.28, stdev=51210.91
      clat (usec): min=5, max=59997, avg=200.81, stdev=1933.63
       lat (usec): min=5, max=59998, avg=201.14, stdev=1935.03
      clat percentiles (usec):
       |  1.00th=[    6],  5.00th=[    6], 10.00th=[    6], 20.00th=[    6],
       | 30.00th=[    7], 40.00th=[    7], 50.00th=[    7], 60.00th=[    7],
       | 70.00th=[    7], 80.00th=[    7], 90.00th=[    7], 95.00th=[    9],
       | 99.00th=[ 6980], 99.50th=[20055], 99.90th=[22938], 99.95th=[26870],
       | 99.99th=[35914]
     bw (  KiB/s): min= 1440, max=675227, per=100.00%, avg=158732.38, stdev=18465.25, samples=956
     iops        : min=  360, max=168806, avg=39683.08, stdev=4616.31, samples=956
    lat (usec)   : 10=95.51%, 20=0.84%, 50=1.15%, 100=0.69%, 250=0.61%
    lat (usec)   : 500=0.05%, 750=0.01%, 1000=0.01%
    lat (msec)   : 2=0.02%, 4=0.04%, 10=0.12%, 20=0.60%, 50=0.35%
    lat (msec)   : 100=0.01%
    cpu          : usr=39.64%, sys=0.00%, ctx=27202, majf=0, minf=8
    IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
       submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
       complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
       issued rwts: total=0,2380721,0,0 short=0,0,0,0 dropped=0,0,0,0
       latency   : target=0, window=0, percentile=100.00%, depth=1

  Run status group 0 (all jobs):
    WRITE: bw=155MiB/s (162MB/s), 155MiB/s-155MiB/s (162MB/s-162MB/s), io=9300MiB (9751MB), run=60012-60012msec

```

[1] https://github.com/sejun000/spdk/pull/1