### PR TITLE
Hyeongtak/directive specific

### DIFF
--- a/nvme.h
+++ b/nvme.h
@@ -367,7 +367,8 @@ struct nvme_rw_command {
 	__le64 slba;
 	__le16 length;
 	__le16 control;
-	__le32 dsmgmt;
+	__le16 dsmgmt;
+	__le16 dspec;
 	__le32 reftag;
 	__le16 apptag;
 	__le16 appmask;


### PR DESCRIPTION
This patch series enable NVMeVirt to get `dspec` value of nvme command (write command).

A simple test command is as follows:

```
$ printf "hello world" | dd bs=1 count=11 conv=notrunc of=data.bin
$ dd if=/dev/zero bs=1 count=131072 conv=notrunc of=data.bin oflag=append
$ nvme io-passthru /dev/nvme0n1 --opcode=0x01 --namespace-id=1 --data-len=16384 --cdw10=0 --cdw11=0 --cdw12=0x1f --cdw13=0 --write --raw-binary < data.bin
```
