### PR TITLE
Hyeongtak/new multi stream

### DIFF
--- a/Kbuild
+++ b/Kbuild
@@ -11,7 +11,7 @@ ccflags-y += -Wno-unused-variable -Wno-unused-function
 ccflags-$(CONFIG_NVMEVIRT_NVM) += -DBASE_SSD=INTEL_OPTANE
 nvmev-$(CONFIG_NVMEVIRT_NVM) += simple_ftl.o
 
-ccflags-$(CONFIG_NVMEVIRT_SSD) += -DBASE_SSD=SAMSUNG_970PRO
+ccflags-$(CONFIG_NVMEVIRT_SSD) += -DBASE_SSD=MULTI_STREAM_SSD
 nvmev-$(CONFIG_NVMEVIRT_SSD) += ssd.o conv_ftl.o pqueue/pqueue.o channel_model.o
 
 ccflags-$(CONFIG_NVMEVIRT_ZNS) += -DBASE_SSD=WD_ZN540

--- a/conv_ftl.c
+++ b/conv_ftl.c
@@ -49,6 +49,11 @@ static const struct proc_ops write_count_fops = {
 	.proc_release = single_release,
 };
 
+static uint32_t get_nr_streams(struct conv_ftl *conv_ftl)
+{
+	return conv_ftl->ssd->sp.nstreams;
+}
+
 static inline bool last_pg_in_wordline(struct conv_ftl *conv_ftl, struct ppa *ppa)
 {
 	struct ssdparams *spp = &conv_ftl->ssd->sp;
@@ -995,6 +1000,7 @@ static bool conv_write(struct nvmev_ns *ns, struct nvmev_request *req, struct nv
 
 	struct nvme_command *cmd = req->cmd;
 	uint64_t lba = cmd->rw.slba;
+	uint32_t stream_id = (cmd->rw.dspec % get_nr_streams(conv_ftl));
 	uint64_t nr_lba = (cmd->rw.length + 1);
 	uint64_t start_lpn = lba / spp->secs_per_pg;
 	uint64_t end_lpn = (lba + nr_lba - 1) / spp->secs_per_pg;
@@ -1013,7 +1019,8 @@ static bool conv_write(struct nvmev_ns *ns, struct nvmev_request *req, struct nv
 		.xfer_size = spp->pgsz * spp->pgs_per_oneshotpg,
 	};
 
-	NVMEV_DEBUG_VERBOSE("%s: start_lpn=%lld, len=%lld, end_lpn=%lld", __func__, start_lpn, nr_lba, end_lpn);
+	NVMEV_DEBUG_VERBOSE("%s: start_lpn=%lld, len=%lld, end_lpn=%lld, stream=%d", __func__, start_lpn, nr_lba, end_lpn, stream_id);
+
 	if ((end_lpn / nr_parts) >= spp->tt_pgs) {
 		NVMEV_ERROR("%s: lpn passed FTL range (start_lpn=%lld > tt_pgs=%ld)\n",
 				__func__, start_lpn, spp->tt_pgs);

--- a/conv_ftl.h
+++ b/conv_ftl.h
@@ -61,7 +61,7 @@ struct conv_ftl {
 	struct convparams cp;
 	struct ppa *maptbl; /* page level mapping table */
 	uint64_t *rmap; /* reverse mapptbl, assume it's stored in OOB */
-	struct write_pointer wp;
+	struct write_pointer *wp;
 	struct write_pointer gc_wp;
 	struct line_mgmt lm;
 	struct write_flow_control wfc;

--- a/main.c
+++ b/main.c
@@ -578,6 +578,8 @@ static void __print_base_config(void)
 	case WD_ZN540:
 		type = "WD ZN540 ZNS SSD";
 		break;
+	case MULTI_STREAM_SSD:
+		type = "MULTI STREAM SSD";
 	}
 
 	NVMEV_INFO("Version %x.%x for >> %s <<\n",

--- a/nvme.h
+++ b/nvme.h
@@ -367,7 +367,8 @@ struct nvme_rw_command {
 	__le64 slba;
 	__le16 length;
 	__le16 control;
-	__le32 dsmgmt;
+	__le16 dsmgmt;
+	__le16 dspec;
 	__le32 reftag;
 	__le16 apptag;
 	__le16 appmask;

--- a/ssd.c
+++ b/ssd.c
@@ -76,6 +76,8 @@ void ssd_init_params(struct ssdparams *spp, uint64_t capacity, uint32_t nparts)
 	spp->luns_per_ch = LUNS_PER_NAND_CH;
 	spp->cell_mode = CELL_MODE;
 
+	spp->nstreams = NR_STREAMS;
+
 	/* partitioning SSD by dividing channel*/
 	NVMEV_ASSERT((spp->nchs % nparts) == 0);
 	spp->nchs /= nparts;
@@ -162,11 +164,12 @@ void ssd_init_params(struct ssdparams *spp, uint64_t capacity, uint32_t nparts)
 		     spp->secsz * spp->secs_per_pg;
 	blk_size = spp->pgs_per_blk * spp->secsz * spp->secs_per_pg;
 	NVMEV_INFO(
-		"Total Capacity(GiB,MiB)=%llu,%llu chs=%u luns=%lu lines=%lu blk-size(MiB,KiB)=%u,%u line-size(MiB,KiB)=%lu,%lu",
+		"Total Capacity(GiB,MiB)=%llu,%llu chs=%u luns=%lu lines=%lu blk-size(MiB,KiB)=%u,%u line-size(MiB,KiB)=%lu,%lu, nr_streams=%d",
 		BYTE_TO_GB(total_size), BYTE_TO_MB(total_size), spp->nchs, spp->tt_luns,
 		spp->tt_lines, BYTE_TO_MB(spp->pgs_per_blk * spp->pgsz),
 		BYTE_TO_KB(spp->pgs_per_blk * spp->pgsz), BYTE_TO_MB(spp->pgs_per_line * spp->pgsz),
-		BYTE_TO_KB(spp->pgs_per_line * spp->pgsz));
+		BYTE_TO_KB(spp->pgs_per_line * spp->pgsz),
+		spp->nstreams);
 }
 
 static void ssd_init_nand_page(struct nand_page *pg, struct ssdparams *spp)

--- a/ssd.h
+++ b/ssd.h
@@ -158,6 +158,7 @@ struct ssdparams {
 	int pls_per_lun; /* # of planes per LUN (Die) */
 	int luns_per_ch; /* # of LUNs per channel */
 	int nchs; /* # of channels in the SSD */
+	int nstreams; /* # of streams in the SSD */
 	int cell_mode;
 
 	/* Unit size of NVMe write command

--- a/ssd_config.h
+++ b/ssd_config.h
@@ -9,6 +9,7 @@
 #define ZNS_PROTOTYPE 2
 #define KV_PROTOTYPE 3
 #define WD_ZN540 4
+#define MULTI_STREAM_SSD 5
 
 /* SSD Type */
 #define SSD_TYPE_NVM 0
@@ -60,7 +61,7 @@ enum {
 #define LBA_BITS (9)
 #define LBA_SIZE (1 << LBA_BITS)
 
-#elif (BASE_SSD == SAMSUNG_970PRO)
+#elif (BASE_SSD == SAMSUNG_970PRO || BASE_SSD == MULTI_STREAM_SSD)
 #define NR_NAMESPACES 1
 
 #define NS_SSD_TYPE_0 SSD_TYPE_CONV
@@ -70,6 +71,11 @@ enum {
 #define MDTS (6)
 #define CELL_MODE (CELL_MODE_MLC)
 
+#if (BASE_SSD == MULTI_STREAM_SSD)
+#define NR_STREAMS (2)
+#else
+#define NR_STREAMS (1)
+#endif
 #define SSD_PARTITIONS (4)
 #define NAND_CHANNELS (8)
 #define LUNS_PER_NAND_CH (2)


### PR DESCRIPTION
# Overview

This patch series introduces multi-stream SSD support in NVMeVirt. The changes are divided into three main parts:

1. Introduce "MULTI_STREAM_SSD" Type: The number of streams is configurable via `ssd_config.h`.
2. Handle Directive Specifiers: Extract directive specifiers from NVMe write commands.
3. Utilize Stream Hints: Integrate stream hints into the conventional FTL.

# Test Results
I tested the multi-stream SSD feature in NVMeVirt using fio with SPDK (thanks to @sejun000 for the repository, https://github.com/EatingMuch/spdk/tree/multistream-fio).  Below is the fio configuration used for the tests:

```
# spdk_fio_nvme_example.fio
[global]
ioengine=build/fio/spdk_nvme
thread=1
group_reporting=1
direct=1
verify=0

[job0]
rw=randwrite
bs=4k
numjobs=4
time_based=1
runtime=300
offset=0
size=4G
iodepth=4
filename=trtype=PCIe traddr=0001\:10\:00.0 directive_id=1 ns=1

[job1]
rw=randwrite
bs=4k
numjobs=4
time_based=1
runtime=300
offset=4G
size=8G
iodepth=4
filename=trtype=PCIe traddr=0001\:10\:00.0 directive_id=2 ns=1
```

## Results with 2 Streams

```
$ sudo fio ./multistream_fio.conf
job0: (g=0): rw=randwrite, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=spdk, iodepth=4
...
job1: (g=0): rw=randwrite, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=spdk, iodepth=4
...
fio-3.37-31-gd3bc
Starting 8 threads
Jobs: 5 (f=4): [w(4),_(2),w(1),_(1)][100.0%][w=632MiB/s][w=162k IOPS][eta 00m:00s]
job0: (groupid=0, jobs=8): err= 0: pid=919: Fri May 24 07:28:32 2024
  write: IOPS=141k, BW=549MiB/s (576MB/s)(161GiB/300006msec); 0 zone resets
    slat (nsec): min=98, max=17975k, avg=226.18, stdev=29259.47
    clat (usec): min=5, max=66446, avg=116.50, stdev=1291.65
     lat (usec): min=5, max=66448, avg=116.73, stdev=1292.34
    clat percentiles (usec):
     |  1.00th=[    6],  5.00th=[    7], 10.00th=[    7], 20.00th=[    7],
     | 30.00th=[    8], 40.00th=[    9], 50.00th=[   11], 60.00th=[   12],
     | 70.00th=[   13], 80.00th=[   20], 90.00th=[   33], 95.00th=[   46],
     | 99.00th=[   92], 99.50th=[10028], 99.90th=[20055], 99.95th=[20055],
     | 99.99th=[22938]
   bw (  KiB/s): min= 3048, max=2245632, per=100.00%, avg=562507.63, stdev=109929.99, samples=2995
   iops        : min=  762, max=561408, avg=140626.81, stdev=27482.50, samples=2995
  lat (usec)   : 10=47.69%, 20=33.06%, 50=15.24%, 100=3.13%, 250=0.15%
  lat (usec)   : 500=0.01%, 750=0.01%, 1000=0.01%
  lat (msec)   : 2=0.01%, 4=0.03%, 10=0.14%, 20=0.47%, 50=0.07%
  lat (msec)   : 100=0.01%
  cpu          : usr=54.73%, sys=2.32%, ctx=126104, majf=0, minf=15
  IO depths    : 1=0.5%, 2=0.1%, 4=99.5%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=0,42189610,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=4

Run status group 0 (all jobs):
  WRITE: bw=549MiB/s (576MB/s), 549MiB/s-549MiB/s (576MB/s-576MB/s), io=161GiB (173GB), run=300006-300006msec
```

## Results with 1 Stream (as-is)

```
job0: (g=0): rw=randwrite, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=spdk, iodepth=4
...
job1: (g=0): rw=randwrite, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=spdk, iodepth=4
...
fio-3.37-31-gd3bc
Starting 8 threads
Jobs: 5 (f=5): [w(4),_(2),w(1),_(1)][100.0%][w=546MiB/s][w=140k IOPS][eta 00m:00s]
job0: (groupid=0, jobs=8): err= 0: pid=1141: Fri May 24 07:50:39 2024
  write: IOPS=136k, BW=530MiB/s (556MB/s)(155GiB/300003msec); 0 zone resets
    slat (nsec): min=98, max=24011k, avg=225.20, stdev=29161.22
    clat (usec): min=5, max=45033, avg=120.90, stdev=1320.98
     lat (usec): min=5, max=45033, avg=121.13, stdev=1321.64
    clat percentiles (usec):
     |  1.00th=[    6],  5.00th=[    7], 10.00th=[    7], 20.00th=[    7],
     | 30.00th=[    8], 40.00th=[    9], 50.00th=[   11], 60.00th=[   12],
     | 70.00th=[   14], 80.00th=[   21], 90.00th=[   34], 95.00th=[   47],
     | 99.00th=[   94], 99.50th=[10028], 99.90th=[20055], 99.95th=[20055],
     | 99.99th=[22938]
   bw (  KiB/s): min= 3048, max=2246249, per=99.94%, avg=542783.51, stdev=105430.77, samples=2995
   iops        : min=  762, max=561562, avg=135695.80, stdev=26357.70, samples=2995
  lat (usec)   : 10=46.01%, 20=33.89%, 50=15.92%, 100=3.27%, 250=0.16%
  lat (usec)   : 500=0.01%, 750=0.01%, 1000=0.01%
  lat (msec)   : 2=0.02%, 4=0.03%, 10=0.14%, 20=0.49%, 50=0.08%
  cpu          : usr=54.85%, sys=2.20%, ctx=123388, majf=0, minf=15
  IO depths    : 1=0.5%, 2=0.1%, 4=99.5%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=0,40733875,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=4

Run status group 0 (all jobs):
  WRITE: bw=530MiB/s (556MB/s), 530MiB/s-530MiB/s (556MB/s-556MB/s), io=155GiB (167GB), run=300003-300003msec
```

There is a performance gain with the multi-stream SSDs, although it is relatively small (maybe we need to think about ramp up times).