### PR TITLE
conv_ftl: add procfs on conv_ftl

### DIFF
--- a/ssd.c
+++ b/ssd.c
@@ -357,6 +357,8 @@ uint64_t ssd_advance_write_buffer(struct ssd *ssd, uint64_t request_time, uint64
 	return nsecs_latest;
 }
 
+extern uint64_t nand_write_count;
+
 uint64_t ssd_advance_nand(struct ssd *ssd, struct nand_cmd *ncmd)
 {
 	int c = ncmd->cmd;
@@ -426,6 +428,7 @@ uint64_t ssd_advance_nand(struct ssd *ssd, struct nand_cmd *ncmd)
 		nand_etime = nand_stime + spp->pg_wr_lat;
 		lun->next_lun_avail_time = nand_etime;
 		completed_time = nand_etime;
+		nand_write_count +=  ncmd->xfer_size / spp->pgsz;
 		break;
 
 	case NAND_ERASE:


### PR DESCRIPTION
This patch adds procfs on `conv_ftl` as follows:

```
  $ tree /proc/nvmev/
  /proc/nvmev/
  ├── debug
  ├── ftls
  │   ├── ftl0
  │   │   └── free_line_cnt
  │   ├── ftl1
  │   │   └── free_line_cnt
  │   ├── ftl2
  │   │   └── free_line_cnt
  │   └── ftl3
  │       └── free_line_cnt
  ├── io_units
  ├── read_times
  ├── stat
  └── write_times

  $ cat /proc/nvmev/ftls/ftl*/free_line_cnt
  8190
  8190
  8190
  8190
```

Please note that `free_line_cnt` is just a sample.