### PR TITLE
Hyeongtak/test script refactor

### DIFF
--- a/test_script/basic/basic_test.py
+++ b/test_script/basic/basic_test.py
@@ -3,6 +3,7 @@ import re
 import time
 import sys
 import os
+import argparse
 from collections import defaultdict
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -15,9 +16,12 @@ with open('fio_template.fio', 'r') as file:
 
 # Configuration for each test case
 configs = [
-    {'job0_rw': 'write', 'job0_bs': '128k', 'job0_iodepth': 4, 'job1_rw': 'write', 'job1_bs': '128k', 'job1_iodepth': 4},
-    {'job0_rw': 'write', 'job0_bs': '128k', 'job0_iodepth': 4, 'job1_rw': 'randwrite', 'job1_bs': '4k', 'job1_iodepth': 16},
-    {'job0_rw': 'randwrite', 'job0_bs': '4k', 'job0_iodepth': 16, 'job1_rw': 'randwrite', 'job1_bs': '4k', 'job1_iodepth': 16}
+    {'job0_rw': 'write', 'job0_bs': '128k', 'job0_iodepth': 4,
+     'job1_rw': 'write', 'job1_bs': '128k', 'job1_iodepth': 4},
+    {'job0_rw': 'write', 'job0_bs': '128k', 'job0_iodepth': 4,
+     'job1_rw': 'randwrite', 'job1_bs': '4k', 'job1_iodepth': 16},
+    {'job0_rw': 'randwrite', 'job0_bs': '4k', 'job0_iodepth': 16,
+     'job1_rw': 'randwrite', 'job1_bs': '4k', 'job1_iodepth': 16}
 ]
 
 # Function to parse bandwidth log
@@ -54,23 +58,25 @@ def run_fio(config, output_file):
     fio_script = fio_template.format(**config)
     with open('current_fio_script.fio', 'w') as f:
         f.write(fio_script)
-    
+
     # Run make.sh and insmod.sh before starting the test
     util.run_command("../make.sh", "make.sh")
     util.run_command("../insmod.sh", "insmod.sh")
     util.run_command("rm -rf test*waf", "remove test waf output")
-    
+
     # Start fio
     fio_process = subprocess.Popen(['fio', 'current_fio_script.fio'])
     for every_second in range(0, 60): # during 60s
-        nand_write_count = util.read_proc_file("/proc/nvmev/ftls/nand_write_count")
-        write_count = util.read_proc_file("/proc/nvmev/ftls/write_count")
+        nand_write_count = util.read_proc_file(
+            "/proc/nvmev/ftls/nand_write_count")
+        write_count = util.read_proc_file(
+            "/proc/nvmev/ftls/write_count")
         with open(output_file + ".waf", 'a') as rf:
             rf.write(f"{every_second} {nand_write_count} {write_count}\n")
         time.sleep(1)
     fio_process.wait()
     util.run_command("fio current_fio_script.fio", "fio")
- 
+
     # Parse bandwidth logs
     job0_data = parse_bw_log('write_bw.1.log')
     job1_data = parse_bw_log('write_bw.2.log')
@@ -82,15 +88,31 @@ def run_fio(config, output_file):
     with open(output_file, 'w') as f:
         for t in sorted(combined_bandwidths.keys()):
             f.write(f"{t:.3f} {combined_bandwidths[t]}\n")
-            print(f"Time: {t:.3f}s, Combined Bandwidth: {combined_bandwidths[t]} KB/s")
-    
+
     # Run rmmod.sh after finishing the test
     util.run_command("../rmmod.sh", "rmmod.sh")
 
-# Run all test cases
-for i, config in enumerate(configs):
-    output_file = f'test{i}.output'
-    print(f"Starting test case {i+1}")
-    run_fio(config, output_file)
-    print(f"Completed test case {i+1}")
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run fio benchmarks and process output.")
+    parser.add_argument("--result", default="result",
+                        help="Directory to save result files.")
+    args = parser.parse_args()
 
+    if os.path.exists(args.result):
+        print(f"Warning: The directory '{args.result}' already exists.")
+        sys.exit(1)
+
+    os.makedirs(args.result, exist_ok=True)
+
+    # Run all test cases
+    for i, config in enumerate(configs):
+        output_file = os.path.join(args.result,
+            f"{config['job0_rw']}_{config['job0_bs']}_{config['job0_iodepth']}_"
+            f"{config['job1_rw']}_{config['job1_bs']}_{config['job1_iodepth']}.log")
+        print(f"Starting test case {i+1}")
+        run_fio(config, output_file)
+        print(f"Completed test case {i+1}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This patch series refactors "basic_test.py".  It uses argparse to add `--result` and `--plot` options.  `--plot` is to create time-bandwidth graph.  A simple usage is as follows:

```
  $ sudo python ./basic_test.py --plot result.png
  $ ls
  randwrite_4k_16_randwrite_4k_16.log      write_128k_4_randwrite_4k_16.log.waf
  randwrite_4k_16_randwrite_4k_16.log.waf  write_128k_4_write_128k_4.log
  result.png                               write_128k_4_write_128k_4.log.waf
  write_128k_4_randwrite_4k_16.log
  $ cat write_128k_4_write_128k_4.log
  1.000 2286208
  2.000 2286464
  3.000 2286720
  4.000 2285056
  ...
 ```